### PR TITLE
Fix : 모달 렌더링 개선을 위해 MUI Portal로 교체

### DIFF
--- a/src/components/molecule/Modal/index.tsx
+++ b/src/components/molecule/Modal/index.tsx
@@ -26,11 +26,11 @@ function Modal({ children, onClose }: IModalProps) {
     <>
       <Dimmed onClick={onClose} />
       <Container>
+        <Box sx={{ p: 1, my: 1 }} ref={container} />
         <Portal container={container.current}>
           <CloseBtn onClick={onClose}>X</CloseBtn>
           {children}
         </Portal>
-        <Box sx={{ p: 1, my: 1 }} ref={container} />
       </Container>
     </>
   );

--- a/src/components/molecule/Modal/index.tsx
+++ b/src/components/molecule/Modal/index.tsx
@@ -1,7 +1,10 @@
-import { Z_INDEX } from '@/styles';
 import { useState, useEffect, ReactNode, useRef } from 'react';
-import ReactDOM from 'react-dom';
 import styled from 'styled-components';
+
+import Portal from '@mui/base/Portal';
+import { Box } from '@mui/system';
+
+import { Z_INDEX } from '@/styles';
 
 interface IModalProps {
   children: ReactNode;
@@ -10,46 +13,27 @@ interface IModalProps {
 
 function Modal({ children, onClose }: IModalProps) {
   const [isCSR, setIsCSR] = useState<boolean>(false);
-  const portalRef = useRef<HTMLDivElement>(document.createElement('div'));
+  const container = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setIsCSR(true);
   }, []);
 
-  useEffect(() => {
-    portalRef.current.id = 'modal';
-
-    const makePortal = () => {
-      document.body.style.overflow = 'hidden';
-      document.body.appendChild(portalRef.current);
-    };
-
-    const removePortal = () => {
-      document.body.style.overflow = '';
-      document.body.removeChild(portalRef.current);
-    };
-
-    makePortal();
-    return () => removePortal();
-  }, []);
-
   if (typeof window === 'undefined') return <></>;
   if (!isCSR) return <></>;
 
-  const Portal = ReactDOM.createPortal(
+  return (
     <>
       <Dimmed onClick={onClose} />
       <Container>
-        <CloseBtn onClick={onClose}>
-          <div>X</div>
-        </CloseBtn>
-        {children}
+        <Portal container={container.current}>
+          <CloseBtn onClick={onClose}>X</CloseBtn>
+          {children}
+        </Portal>
+        <Box sx={{ p: 1, my: 1 }} ref={container} />
       </Container>
-    </>,
-    document.body,
+    </>
   );
-
-  return Portal;
 }
 
 export default Modal;


### PR DESCRIPTION
### PR Type

- [ ] 버그 수정
- [ ] 신규 기능
- [x] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- 렌더링 개선을 위해 MUI Portal로 교체

<img width="901" alt="image" src="https://user-images.githubusercontent.com/98295004/215548215-5e095aa8-d1be-4abd-8e1d-5e07ed297113.png">


### 중점적으로 봤으면 하는 부분
- dom 직접 조작 영향인지 Portal이 늦게 렌더링 되는 것 같아
  mui의 Portal 컴포넌트로 교체해봄

- 체감상 차이가 크게 느껴지진 않았지만
   LightHouse 측정을 해보니 TTI, LCP가 조금 줄어들었음 (모달 렌더링까지 측정해주나? 궁금)

- 직접 dom 조작하는 건 지양해야겠다..!

<br />

Before - 직접 dom 조작
<img width="641" alt="image" src="https://user-images.githubusercontent.com/98295004/215548420-17cafb0f-ff78-4c66-8519-9739f80f5267.png">

After - mui Portal
<img width="623" alt="image" src="https://user-images.githubusercontent.com/98295004/215548598-344f2066-5480-4029-9e3c-292aa1667c05.png">

