### PR TITLE
Fix : 모달 렌더링 개선을 위해 Thumbnail 분리

### DIFF
--- a/src/components/molecule/Cards/Card.tsx
+++ b/src/components/molecule/Cards/Card.tsx
@@ -1,4 +1,4 @@
-import { useState, memo } from 'react';
+import { useState, memo, useCallback } from 'react';
 import Image from 'next/image';
 import styled from 'styled-components';
 
@@ -15,9 +15,9 @@ interface ICardProps<T> {
 function Card<T extends ICardData>({ data }: ICardProps<T>) {
   const [showModal, setShowModal] = useState(false);
 
-  const toggleModal = () => {
+  const toggleModal = useCallback(() => {
     setShowModal((prev) => !prev);
-  };
+  }, []);
 
   return (
     <>

--- a/src/components/molecule/Cards/Card.tsx
+++ b/src/components/molecule/Cards/Card.tsx
@@ -1,12 +1,12 @@
+import { useState, memo } from 'react';
 import Image from 'next/image';
 import styled from 'styled-components';
-import { useState } from 'react';
 
 import { Grid } from '@mui/material';
 import Modal from '@/components/molecule/Modal';
+import CardDetail from './CardDetail';
 
 import { ICardData } from '@/types/store';
-import CardDetail from './CardDetail';
 
 interface ICardProps<T> {
   data: T;
@@ -15,19 +15,13 @@ interface ICardProps<T> {
 function Card<T extends ICardData>({ data }: ICardProps<T>) {
   const [showModal, setShowModal] = useState(false);
 
-  const handleCardClick = () => {
-    toggleModal();
-  };
-
   const toggleModal = () => {
     setShowModal((prev) => !prev);
   };
 
   return (
     <>
-      <Grid item sm={6} md={2.4} onClick={handleCardClick}>
-        <Thumbnail alt="image" src={data.thumb} width={200} height={200} />
-      </Grid>
+      <Card.Thumb src={data.thumb} onClick={toggleModal} />
       {showModal && (
         <Modal onClose={toggleModal}>
           <CardDetail />
@@ -38,6 +32,21 @@ function Card<T extends ICardData>({ data }: ICardProps<T>) {
 }
 
 export default Card;
+
+interface ICardThumbProps {
+  src: string;
+  onClick: () => void;
+}
+
+function CardThumb({ src, onClick }: ICardThumbProps) {
+  return (
+    <Grid item sm={6} md={2.4} onClick={onClick}>
+      <Thumbnail alt="image" src={src} width={200} height={200} />
+    </Grid>
+  );
+}
+
+Card.Thumb = memo(CardThumb);
 
 const Thumbnail = styled(Image)`
   border-radius: 8px;


### PR DESCRIPTION
### PR Type

- [ ] 버그 수정
- [ ] 신규 기능
- [x] 기타 (기타인 경우 내용 입력 : )

### 해당 PR의 목적
- 모달 렌더링 개선을 위해 Thumbnail 분리

### 중점적으로 봤으면 하는 부분
- 모달 렌더링할 때 ThumbNail이 같이 리렌더링 되는 것 같아서 분리 해줌
- toggleModal 때문에 리렌더링 되지 않도록 useCallBack 적용

<br />

- before : React.memo + useCallback 적용 전

<img width="476" alt="image" src="https://user-images.githubusercontent.com/98295004/215553539-56456679-4ddc-4108-8111-5b8a4a749781.png">


- after : 적용 후

![image](https://user-images.githubusercontent.com/98295004/215553588-b3753215-d0a1-4de7-a63b-dd595b6e171e.png)
