### PR TITLE
Add : Store 페이지 Cards 구조 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "13.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-query": "^3.39.3",
     "styled-components": "^5.3.6",
     "typescript": "4.9.4"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { usePathname } from 'next/navigation';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { PageTitle } from '@/components/molecule';
 import { Header, Footer, Layout, WrapperLayout, ContentsLayout } from '@/components/template';
@@ -15,6 +16,8 @@ const theme = createTheme({
     fontFamily: 'Spoqa Han Sans Neo',
   },
 });
+
+const queryClient = new QueryClient();
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const path = usePathname();
@@ -34,15 +37,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <StyledComponentsRegistry>
           <ThemeProvider theme={theme}>
-            <Layout>
-              <Header />
-              <PageTitle>{pathname}</PageTitle>
-              <WrapperLayout>
-                <ContentsLayout pathname={pathname}>{children}</ContentsLayout>
-              </WrapperLayout>
-              <Footer />
-            </Layout>
-            <div id="modal"></div>
+            <QueryClientProvider client={queryClient}>
+              <Layout>
+                <Header />
+                <PageTitle>{pathname}</PageTitle>
+                <WrapperLayout>
+                  <ContentsLayout pathname={pathname}>{children}</ContentsLayout>
+                </WrapperLayout>
+                <Footer />
+              </Layout>
+              <div id="modal"></div>
+            </QueryClientProvider>
           </ThemeProvider>
         </StyledComponentsRegistry>
       </body>

--- a/src/app/store/[id]/page.tsx
+++ b/src/app/store/[id]/page.tsx
@@ -1,5 +1,0 @@
-function StoreDetail() {
-  return <div>StoreDetail 추가하기</div>;
-}
-
-export default StoreDetail;

--- a/src/app/store/components/Card/CardDetail.tsx
+++ b/src/app/store/components/Card/CardDetail.tsx
@@ -1,0 +1,11 @@
+import { ICardData } from '@/types/store';
+
+interface ICardDetailProps {
+  data: ICardData;
+}
+
+function CardDetail({ data }: ICardDetailProps) {
+  return <div>CardDetail</div>;
+}
+
+export default CardDetail;

--- a/src/app/store/components/Card/CardThumb.tsx
+++ b/src/app/store/components/Card/CardThumb.tsx
@@ -3,13 +3,14 @@ import styled from 'styled-components';
 import { Grid } from '@mui/material';
 
 interface ICardThumbProps {
+  id: number;
   src: string;
-  onClick: () => void;
+  onClick: (id: number) => void;
 }
 
-function CardThumb({ src, onClick }: ICardThumbProps) {
+function CardThumb({ id, src, onClick }: ICardThumbProps) {
   return (
-    <Grid item sm={6} md={2.4} onClick={onClick}>
+    <Grid item sm={6} md={2.4} onClick={() => onClick(id)}>
       <Thumbnail alt="image" src={src} width={200} height={200} />
     </Grid>
   );

--- a/src/app/store/components/Store.tsx
+++ b/src/app/store/components/Store.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { Cards } from '@/components/molecule';
-import Card from './Card';
+import { useState, useCallback } from 'react';
 
+import { Cards, Modal } from '@/components/molecule';
+import CardThumb from './Card/CardThumb';
+import CardDetail from './Card/CardDetail';
+
+import useGetStoreDetail from '../queries/useGetStoreDetail';
 import { ICardData } from '@/types/store';
 
 interface IStoreProps {
@@ -10,13 +14,29 @@ interface IStoreProps {
 }
 
 export function Store({ stores }: IStoreProps) {
-  return (
+  const [storeId, setStoreId] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+
+  const { data } = useGetStoreDetail(storeId);
+
+  const handleThumbClick = useCallback((id: number) => {
+    setStoreId(id);
+  }, []);
+
+  const toggleModal = useCallback(() => {
+    setShowModal((prev) => !prev);
+  }, []);
+
+  <>
     <Cards>
       {stores.map((store, idx) => (
-        <Card key={`card-${idx}`} data={store} />
+        <CardThumb key={`store-${idx}`} id={store.id} src={store.thumb} onClick={handleThumbClick} />
       ))}
     </Cards>
-  );
+    <Modal isOpen={showModal} onClose={toggleModal}>
+      <CardDetail data={data} />
+    </Modal>
+  </>;
 }
 
 export default Store;

--- a/src/app/store/queries/useGetStoreDetail.ts
+++ b/src/app/store/queries/useGetStoreDetail.ts
@@ -1,0 +1,15 @@
+import { useQuery } from 'react-query';
+
+const fetchStoreDetail = async (id: number) => {
+  const res = await fetch(`http://localhost:9000/stores/${id}`);
+  const data = await res.json();
+  return data;
+};
+
+const useGetStoreDetail = (id: number) =>
+  useQuery(['Stores', id], () => fetchStoreDetail(id), {
+    enabled: !!id,
+    onError: (error) => console.log(error),
+  });
+
+export default useGetStoreDetail;

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,7 +95,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7":
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
   integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
@@ -824,6 +824,11 @@ basic-auth@~2.0.1:
   dependencies:
     safe-buffer "5.1.2"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 body-parser@1.20.1, body-parser@^1.19.0:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
@@ -856,6 +861,20 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1142,6 +1161,11 @@ destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2204,6 +2228,11 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
   integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2355,6 +2384,14 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -2392,6 +2429,11 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
@@ -2454,6 +2496,13 @@ ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.23, nanoid@^3.3.4:
   version "3.3.4"
@@ -2562,6 +2611,11 @@ object.values@^1.1.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 on-finished@2.4.1:
   version "2.4.1"
@@ -2801,6 +2855,15 @@ react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-query@^3.39.3:
+  version "3.39.3"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"
+  integrity sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
@@ -2837,6 +2900,11 @@ regexpp@^3.2.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -2870,7 +2938,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3254,6 +3322,14 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### PR Type

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 기타

### 해당 PR의 목적
- GET stores/:id API 활용을 위해, Store 페이지 Cards 구조 변경

### 중점적으로 봤으면 하는 부분
- 기존
Cards안에 Card 컴포넌트 여러개를 렌더링하고, Card 안에 썸네일 & 모달 있음 
 
- 변경
Cards안에는 썸네일만 있고, 모달은 Card 외부에 두고 CardDetail만 변경하는 구조

- before
```typescript
<Cards>
      {stores.map((store, idx) => (
        <Card key={`card-${idx}`} data={store} />
      ))}
</Cards>
```
- after
```typescript
 <>
    <Cards>
      {stores.map((store, idx) => (
        <CardThumb key={`store-${idx}`} id={store.id} src={store.thumb} onClick={handleThumbClick} />
      ))}
    </Cards>
    <Modal isOpen={showModal} onClose={toggleModal}>
      <CardDetail data={data} />
    </Modal>
</>;
```